### PR TITLE
Ignore deploy.sh in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,7 +15,7 @@ exclude docs/src/_static/stub
 prune .github/
 
 # Include src, tests, docs
-recursive-include docs *.rst *.py *.gitkeep
+recursive-include docs *.rst *.py *.gitkeep *.sh
 include docs/requirements.txt
 prune docs/build
 prune docs/src/reference


### PR DESCRIPTION
We don't need documentation deploy script in the package.