### PR TITLE
Update robo to newer Orion version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     env:
       PLATFORM: ${{ matrix.platform }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -40,25 +40,25 @@ Installation
 The RoBO wrapper is currently only supported on Linux.
 
 Before installing RoBO, make sure you have ``libeigen`` and ``swig`` installed. 
-On ubuntu, you can install them with ``apt-get``
+On ubuntu, you can install them with ``apt-get``, like so:
 
 .. code-block:: console
 
     $ sudo apt-get install libeigen3-dev swig
 
-One of the dependencies of RoBO does not declare its dependencies and therefore we need
-to install these dependencies first. The order of dependencies in ``requirements.txt`` 
-reflects this order. To install them sequentially, use the following command
+Then, the repo can be installed, like so:
+
 
 .. code-block:: console
 
-    $ curl -s https://git.io/JLnCA | grep -v "^#" | xargs -n 1 -L 1 pip install
+    $ pip install git+https://github.com/Epistimio/orion.algo.robo
 
-Finally, you can install this package using PyPI
+..  TODO: Can we get this to be installable with PyPI even with links? How does Benzina do it?
+.. Finally, you can install this package using PyPI
 
-.. code-block:: console
+.. .. code-block:: console
 
-    $ pip install orion.algo.robo
+..     $ pip install orion.algo.robo
 
 
 Contribute or Ask

--- a/README.rst
+++ b/README.rst
@@ -29,36 +29,35 @@ RoBO Wrapper for Oríon
 
 ----
 
-This wrapper provides access through `Oríon`_ to several Bayesian optimization algorithms 
+This wrapper provides access through `Oríon`_ to several Bayesian optimization algorithms
 in the library `RoBO`_.
 
-This ``orion.algo`` plugin was generated with `Cookiecutter`_ along with `@Epistimio`_'s `cookiecutter-orion.algo`_ template.
+This ``orion.algo`` plugin was generated with `Cookiecutter`_ along with `@Epistimio`_'s
+`cookiecutter-orion.algo`_ template.
 
 Installation
 ------------
 
 The RoBO wrapper is currently only supported on Linux.
 
-Before installing RoBO, make sure you have ``libeigen`` and ``swig`` installed. 
+Before installing RoBO, make sure you have ``libeigen`` and ``swig`` installed.
 On ubuntu, you can install them with ``apt-get``, like so:
 
 .. code-block:: console
 
     $ sudo apt-get install libeigen3-dev swig
 
-Then, the repo can be installed, like so:
-
+The RoBO wrapper can then be installed, either from source, like so:
 
 .. code-block:: console
 
     $ pip install git+https://github.com/Epistimio/orion.algo.robo
 
-..  TODO: Can we get this to be installable with PyPI even with links? How does Benzina do it?
-.. Finally, you can install this package using PyPI
+Or from PyPI:
 
-.. .. code-block:: console
+.. code-block:: console
 
-..     $ pip install orion.algo.robo
+    $ pip install orion.algo.robo
 
 
 Contribute or Ask
@@ -79,9 +78,9 @@ Citation
 --------
 
 If you use this wrapper for your publications, please cite both
-`RoBO <https://github.com/automl/RoBO#citing-robo>`__ and 
+`RoBO <https://github.com/automl/RoBO#citing-robo>`__ and
 `Oríon <https://github.com/epistimio/orion#citation>`__. Please also cite
-the papers of the algorithms you used, such as DNGO or BOHAMIANN. See 
+the papers of the algorithms you used, such as DNGO or BOHAMIANN. See
 the documentation of the algorithms to find corresponding original papers.
 
 License

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -81,7 +81,7 @@ version = re.sub(r"(\d+)(\.\d+)?(?:\.\d+)?(?:-.*)?(?:\.post\d+)?", r"\1\2", rele
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # orion.algo.robo documentation build configuration file.
 #
@@ -11,11 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import glob
+import os
 import re
 import sys
-import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -65,7 +62,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"orion.algo.robo"
+project = "orion.algo.robo"
 _full_version = algo_plugin.__version__
 copyright = algo_plugin.__copyright__
 author = algo_plugin.__author__
@@ -122,6 +119,24 @@ pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+type_hints = [
+    "Space",
+    "MaximizerName",
+    "AcquisitionFnName",
+    "SamplingMethod",
+]
+other_buggy_things = [
+    "orion.algo.robo.gp.RoBO_GP.build_model",
+    "orion.algo.robo.gp.RoBO_GP_MCMC.build_model",
+    "orion.algo.robo.randomforest.RoBO_RandomForest.build_model",
+    "orion.algo.robo.dngo.RoBO_DNGO.build_model",
+    "orion.algo.robo.bohamiann.RoBO_BOHAMIANN.build_model",
+]
+nitpicky = True
+nitpick_ignore = [("py:class", annotation_str) for annotation_str in type_hints] + [
+    ("py:obj", buggy_thing) for buggy_thing in other_buggy_things
+]
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -246,13 +261,13 @@ htmlhelp_basename = "robodoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
     # Latex figure (float) alignment
-    #'figure_align': 'htbp',
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -262,8 +277,8 @@ latex_documents = [
     (
         master_doc,
         "orion.algo.robo.tex",
-        u"Oríon algo robo Documentation",
-        u"Xavier Bouthillier",
+        "Oríon algo robo Documentation",
+        "Xavier Bouthillier",
         "manual",
     ),
 ]
@@ -293,7 +308,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "projectname", u"Oríon algo robo Documentation", [author], 1)]
+man_pages = [(master_doc, "projectname", "Oríon algo robo Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -308,7 +323,7 @@ texinfo_documents = [
     (
         master_doc,
         "robo",
-        u"Oríon algo robo Documentation",
+        "Oríon algo robo Documentation",
         author,
         "robo",
         algo_plugin.__descr__,

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -278,7 +278,7 @@ latex_documents = [
         master_doc,
         "orion.algo.robo.tex",
         "Oríon algo robo Documentation",
-        "Xavier Bouthillier",
+        "Epistímio",
         "manual",
     ),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 Cython
-PyYAML
+PyYAML<6.0.0
 Jinja2
 numpy
-git+https://github.com/automl/george.git@development
-git+https://github.com/automl/pybnn.git
 git+https://github.com/automl/RoBO.git

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup_args = dict(
         "Jinja2",
         "tqdm",
         "robo @ git+https://github.com/automl/RoBO.git@91366b12a1a3deb8e80dd08599e0eaf4df28adc1",
+        # DNGO depends on older versions (< 3.0.0), otherwise we have to rewrite the train method:
+        "emcee<3.0.0",
     ],
     tests_require=tests_require,
     setup_requires=["setuptools", "pytest-runner>=2.0,<3dev"],

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ tests_require = ["pytest>=3.0.0", "pytest-mock"]
 
 extras_require = {
     "test": tests_require,
-    # "george": [
-    #     # "george @ git+https://github.com/lebrice/george.git@orion",
-    # ],
 }
 
 setup_args = dict(

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup_args = dict(
     url="https://github.com/Epistimio/orion.algo.robo",
     packages=["orion.algo.robo"],
     package_dir={"": "src"},
+    python_requires=">=3.7",
     include_package_data=True,
     entry_points={
         "BaseAlgorithm": [

--- a/setup.py
+++ b/setup.py
@@ -10,34 +10,50 @@ import versioneer
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
-tests_require = ["pytest>=3.0.0"]
+tests_require = ["pytest>=3.0.0", "pytest-mock"]
+
+extras_require = {
+    "test": tests_require,
+    # "george": [
+    #     # "george @ git+https://github.com/lebrice/george.git@orion",
+    # ],
+}
 
 setup_args = dict(
     name="orion.algo.robo",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description="TODO",
+    description="RoBO Wrapper for Oríon",
     long_description=open(os.path.join(repo_root, "README.rst")).read(),
     license="BSD-3-Clause",
-    author=u"Epistímio",
+    author="Epistímio",
     author_email="xavier.bouthillier@umontreal.ca",
     url="https://github.com/Epistimio/orion.algo.robo",
     packages=["orion.algo.robo"],
     package_dir={"": "src"},
     include_package_data=True,
     entry_points={
-        "OptimizationAlgorithm": [
+        "BaseAlgorithm": [
             "robo_gp = orion.algo.robo.gp:RoBO_GP",
             "robo_gp_mcmc = orion.algo.robo.gp:RoBO_GP_MCMC",
             "robo_randomforest = orion.algo.robo.randomforest:RoBO_RandomForest",
             "robo_dngo = orion.algo.robo.dngo:RoBO_DNGO",
-            "robo_bohamiann= orion.algo.robo.bohamiann:RoBO_BOHAMIANN",
+            "robo_bohamiann = orion.algo.robo.bohamiann:RoBO_BOHAMIANN",
         ],
     },
-    install_requires=["orion>=0.1.11", "numpy", "torch>=1.2.0"],
+    install_requires=[
+        "orion>=0.2.2",
+        "numpy",
+        "torch>=1.2.0",
+        "pyyaml<6.0.0",  # NOTE: This is because of George uses `yaml.load` without passing a Loader
+        "pybind11",
+        "Jinja2",
+        "tqdm",
+        "robo @ git+https://github.com/automl/RoBO.git@91366b12a1a3deb8e80dd08599e0eaf4df28adc1",
+    ],
     tests_require=tests_require,
     setup_requires=["setuptools", "pytest-runner>=2.0,<3dev"],
-    extras_require=dict(test=tests_require),
+    extras_require=extras_require,
     # "Zipped eggs don't play nicely with namespace packaging"
     # from https://github.com/pypa/sample-namespace-packages
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Installation script for `orion.algo.robo`."""
 import os
 
 from setuptools import setup
 
 import versioneer
-
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
@@ -36,7 +34,8 @@ setup_args = dict(
         "BaseAlgorithm": [
             "robo_gp = orion.algo.robo.gp:RoBO_GP",
             "robo_gp_mcmc = orion.algo.robo.gp:RoBO_GP_MCMC",
-            "robo_randomforest = orion.algo.robo.randomforest:RoBO_RandomForest",
+            # TODO: Temporarily disabled.
+            # "robo_randomforest = orion.algo.robo.randomforest:RoBO_RandomForest",
             "robo_dngo = orion.algo.robo.dngo:RoBO_DNGO",
             "robo_bohamiann = orion.algo.robo.bohamiann:RoBO_BOHAMIANN",
         ],

--- a/src/orion/algo/robo/__init__.py
+++ b/src/orion/algo/robo/__init__.py
@@ -5,10 +5,10 @@ Wrapper for RoBO
 
 __descr__ = "TODO"
 __license__ = "BSD 3-Clause"
-__author__ = u"Epistímio"
-__author_short__ = u"Epistímio"
+__author__ = "Epistímio"
+__author_short__ = "Epistímio"
 __author_email__ = "xavier.bouthillier@umontreal.ca"
-__copyright__ = u"2021, Epistímio"
+__copyright__ = "2021, Epistímio"
 __url__ = "https://github.com/Epistimio/orion.algo.robo"
 
 from ._version import get_versions

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -289,7 +289,7 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
 
     @property
     def XY(self) -> tuple[np.ndarray, np.ndarray]:
-        """ Matrix containing trial points and their results. """
+        """Matrix containing trial points and their results."""
         # Keep only the trials that have a result.
         trials_and_objectives: list[tuple[Trial, float]] = [
             (trial, trial.objective.value)

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -30,7 +30,7 @@ from typing_extensions import Literal
 AcquisitionFnName = Literal["ei", "log_ei", "pi", "lcb"]
 MaximizerName = Literal["random", "scipy", "differential_evolution"]
 
-
+# pylint: disable=unsubscriptable-object
 def build_bounds(space: Space) -> tuple[numpy.ndarray, numpy.ndarray]:
     """
     Build bounds of optimization space

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -3,6 +3,7 @@ Base class for RoBO algorithms.
 """
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Generic, Iterable, Sequence, TypeVar
 
@@ -248,6 +249,16 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
         self.robo: BayesianOptimization
         self.rng: numpy.random.RandomState
         self._initialized: bool = False
+
+        # TODO: Remove once the fix of https://github.com/Epistimio/orion/pull/947 is included in
+        # a release of orion.
+        init_signature = inspect.signature(type(self).__init__)
+        self._param_names = [
+            name
+            for name, param in init_signature.parameters.items()
+            if name not in ["self", "space"]
+            and param.kind not in [param.VAR_KEYWORD, param.VAR_POSITIONAL]
+        ]
 
     def _initialize(self, seed_rng: bool = True) -> None:
         if self._initialized:

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Iterable,
     Literal,
     Optional,
@@ -194,9 +195,11 @@ class WrappedRoboModel(BaseModel, ABC):
     def seed(self, seed: int | Sequence[int] | None) -> None:
         ...
 
+    @abstractmethod
     def state_dict(self) -> dict:
         ...
 
+    @abstractmethod
     def set_state(self, state_dict: dict) -> None:
         ...
 
@@ -228,10 +231,6 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
         Defaults to 'random'
     acquisition_func: str
         Name of the acquisition function. Can be one of ``['ei', 'log_ei', 'pi', 'lcb']``.
-    **kwargs:
-        Arguments specific to each RoBO algorithms. These will be registered as part of
-        the algorithm's configuration.
-
     """
 
     requires_type: ClassVar[str] = "real"
@@ -447,13 +446,3 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
             #     return []
 
         return self._suggest(num, suggest_bo)
-
-    @property
-    def is_done(self) -> bool:
-        """Whether the algorithm is done and will not make further suggestions.
-
-        Return True, if an algorithm holds that there can be no further improvement.
-        By default, the cardinality of the specified search space will be used to check
-        if all possible sets of parameters has been tried.
-        """
-        return super().is_done

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -8,11 +8,11 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Generic,
     Iterable,
     Literal,
     Optional,
     Sequence,
-    Generic,
     TypeVar,
 )
 
@@ -24,6 +24,7 @@ from orion.algo.base import BaseAlgorithm
 from orion.algo.space import Space
 from orion.core.utils.format_trials import trial_to_tuple, tuple_to_trial
 from orion.core.worker.trial import Trial
+from pybnn.base_model import BaseModel as PyBnnBaseModel
 from robo.acquisition_functions.base_acquisition import BaseAcquisitionFunction
 from robo.acquisition_functions.ei import EI
 from robo.acquisition_functions.lcb import LCB
@@ -34,7 +35,6 @@ from robo.maximizers.differential_evolution import DifferentialEvolution
 from robo.maximizers.random_sampling import RandomSampling
 from robo.maximizers.scipy_optimizer import SciPyOptimizer
 from robo.models.base_model import BaseModel
-from pybnn.base_model import BaseModel as PyBnnBaseModel
 from robo.priors.default_priors import DefaultPrior
 from robo.solver.bayesian_optimization import BayesianOptimization
 

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -327,8 +327,9 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
     @property
     def state_dict(self) -> dict:
         """Return a state dict that can be used to reset the state of the algorithm."""
+        if not self._initialized:
+            self._initialize()
         s_dict: dict[str, Any] = super().state_dict
-
         s_dict.update(
             {
                 "rng_state": self.rng.get_state(),
@@ -348,10 +349,10 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
         :param state_dict: Dictionary representing state of an algorithm
 
         """
-        super().set_state(state_dict)
         if not self._initialized:
             self._initialize()
 
+        super().set_state(state_dict)
         self.rng.set_state(state_dict["rng_state"])
         numpy.random.set_state(state_dict["global_numpy_rng_state"])
         if self.robo is None or self.model is None:

--- a/src/orion/algo/robo/base.py
+++ b/src/orion/algo/robo/base.py
@@ -427,24 +427,9 @@ class RoBO(BaseAlgorithm, ABC, Generic[ModelType]):
         # pylint: disable = unused-argument
         def suggest_bo(num: int) -> list[Trial]:
             # pylint: disable = protected-access
-            assert self.robo is not None
             X, y = self.XY
             point = list(self.robo.choose_next(X, y))
             trial = tuple_to_trial(point, self.space)
             return [trial]
-            # TODO: Double-check, but I don't think this kind of thing is needed anymore.
-            # # If already suggested, give corresponding result to BO to sample another point
-            # if self.has_suggested(trial):
-            #     existing_trial = self.registry.get_existing(trial)
-            #     result = existing_trial.objective
-            #     if result is None:
-            #         results = []
-            #         for _, other_result in self._trials_info.values():
-            #             if other_result is not None:
-            #                 results.append(other_result["objective"])
-            #         result = Trial.Result(objective=numpy.array(results).mean())
-            #     self._bo_duplicates.append((trial, result))
-            #     # self.optimizer.tell([point], [result])
-            #     return []
 
         return self._suggest(num, suggest_bo)

--- a/src/orion/algo/robo/bohamiann.py
+++ b/src/orion/algo/robo/bohamiann.py
@@ -1,12 +1,21 @@
 """
 Wrapper for RoBO with BOHAMIANN
 """
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy
 import torch
+from orion.algo.space import Space
 from pybnn.bohamiann import Bohamiann
 from robo.models.base_model import BaseModel
 from robo.models.wrapper_bohamiann import get_default_network
+from typing_extensions import Literal
 
-from orion.algo.robo.base import RoBO, build_bounds
+from orion.algo.robo.base import AcquisitionFnName, MaximizerName, RoBO, build_bounds
+
+SamplingMethod = Literal["adaptive_sghmc", "sgld", "preconditioned_sgld", "sghmc"]
 
 
 class RoBO_BOHAMIANN(RoBO):
@@ -79,48 +88,48 @@ class RoBO_BOHAMIANN(RoBO):
 
     def __init__(
         self,
-        space,
-        seed=0,
-        n_initial_points=20,
-        maximizer="random",
-        acquisition_func="log_ei",
-        normalize_input=True,
-        normalize_output=False,
-        burnin_steps=None,
-        sampling_method="adaptive_sghmc",
-        use_double_precision=True,
-        num_steps=None,
-        keep_every=100,
-        learning_rate=1e-2,
-        batch_size=20,
-        epsilon=1e-10,
-        mdecay=0.05,
-        verbose=False,
+        space: Space,
+        seed: int | Sequence[int] | None = 0,
+        n_initial_points: int = 20,
+        maximizer: MaximizerName = "random",
+        acquisition_func: AcquisitionFnName = "log_ei",
+        normalize_input: bool = True,
+        normalize_output: bool = False,
+        burnin_steps: bool | None = None,
+        sampling_method: SamplingMethod = "adaptive_sghmc",
+        use_double_precision: bool = True,
+        num_steps: int | None = None,
+        keep_every: int = 100,
+        learning_rate: float = 1e-2,
+        batch_size: int = 20,
+        epsilon: float = 1e-10,
+        mdecay: float = 0.05,
+        verbose: bool = False,
     ):
 
         super().__init__(
             space,
             maximizer=maximizer,
             acquisition_func=acquisition_func,
-            normalize_input=normalize_input,
-            normalize_output=normalize_output,
-            burnin_steps=burnin_steps,
-            sampling_method=sampling_method,
-            use_double_precision=use_double_precision,
-            num_steps=num_steps,
-            keep_every=keep_every,
-            learning_rate=learning_rate,
-            batch_size=batch_size,
-            epsilon=epsilon,
-            mdecay=mdecay,
-            verbose=verbose,
             n_initial_points=n_initial_points,
             seed=seed,
         )
+        self.normalize_input = normalize_input
+        self.normalize_output = normalize_output
+        self.burnin_steps = burnin_steps
+        self.sampling_method: SamplingMethod = sampling_method
+        self.use_double_precision = use_double_precision
+        self.num_steps = num_steps
+        self.keep_every = keep_every
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.epsilon = epsilon
+        self.mdecay = mdecay
+        self.verbose = verbose
 
-    def _initialize_model(self):
+    def build_model(self):
         lower, upper = build_bounds(self.space)
-        self.model = OrionBohamiannWrapper(
+        return OrionBohamiannWrapper(
             normalize_input=self.normalize_input,
             normalize_output=self.normalize_output,
             burnin_steps=self.burnin_steps,
@@ -184,21 +193,22 @@ class OrionBohamiannWrapper(BaseModel):
 
     def __init__(
         self,
-        lower,
-        upper,
-        sampling_method="adaptive_sghmc",
-        use_double_precision=True,
-        num_steps=None,
-        keep_every=100,
-        burnin_steps=None,
-        learning_rate=1e-2,
-        batch_size=20,
-        epsilon=1e-10,
-        mdecay=0.05,
-        verbose=False,
-        **kwargs
+        lower: numpy.ndarray,
+        upper: numpy.ndarray,
+        sampling_method: SamplingMethod = "adaptive_sghmc",
+        use_double_precision: bool = True,
+        num_steps: int | None = None,
+        keep_every: int = 100,
+        burnin_steps: int | None = None,
+        learning_rate: float = 1e-2,
+        batch_size: int = 20,
+        epsilon: float = 1e-10,
+        mdecay: float = 0.05,
+        verbose: bool = False,
+        **kwargs,
     ):
-
+        self.lower = lower
+        self.upper = upper
         self.num_steps = num_steps
         self.keep_every = keep_every
         self.burnin_steps = burnin_steps
@@ -212,12 +222,9 @@ class OrionBohamiannWrapper(BaseModel):
             get_network=get_default_network,
             sampling_method=sampling_method,
             use_double_precision=use_double_precision,
-            **kwargs
+            **kwargs,
         )
         self.burnin_steps = burnin_steps
-
-        self.lower = lower
-        self.upper = upper
 
     # pylint:disable=no-self-use
     def set_state(self, state_dict):
@@ -238,7 +245,7 @@ class OrionBohamiannWrapper(BaseModel):
 
         torch.manual_seed(seed)
 
-    def train(self, X, y, **kwargs):
+    def train(self, X: numpy.ndarray, y: numpy.ndarray, **kwargs):
         """
         Sets num_steps and burnin_steps before training with parent's train()
         """
@@ -267,9 +274,10 @@ class OrionBohamiannWrapper(BaseModel):
             mdecay=self.mdecay,
             continue_training=False,
             verbose=self.verbose,
-            **kwargs
+            **kwargs,
         )
 
-    def predict(self, X_test):
+    def predict(self, X_test: numpy.ndarray) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Predict using bnn.predict()"""
-        return self.bnn.predict(X_test)
+        mean, variance, *_ = self.bnn.predict(X_test)
+        return mean, variance

--- a/src/orion/algo/robo/bohamiann.py
+++ b/src/orion/algo/robo/bohamiann.py
@@ -98,7 +98,7 @@ class RoBO_BOHAMIANN(RoBO):
         verbose=False,
     ):
 
-        super(RoBO_BOHAMIANN, self).__init__(
+        super().__init__(
             space,
             maximizer=maximizer,
             acquisition_func=acquisition_func,

--- a/src/orion/algo/robo/bohamiann.py
+++ b/src/orion/algo/robo/bohamiann.py
@@ -9,12 +9,17 @@ import numpy
 import torch
 from orion.algo.space import Space
 from pybnn.bohamiann import Bohamiann, nll
-from robo.models.base_model import BaseModel
 from robo.models.wrapper_bohamiann import get_default_network
 from torch import nn
 from typing_extensions import Literal
 
-from orion.algo.robo.base import AcquisitionFnName, MaximizerName, RoBO, build_bounds
+from orion.algo.robo.base import (
+    AcquisitionFnName,
+    MaximizerName,
+    RoBO,
+    WrappedRoboModel,
+    build_bounds,
+)
 
 SamplingMethod = Literal["adaptive_sghmc", "sgld", "preconditioned_sgld", "sghmc"]
 
@@ -148,7 +153,7 @@ class RoBO_BOHAMIANN(RoBO):
         )
 
 
-class OrionBohamiannWrapper(BaseModel):
+class OrionBohamiannWrapper(WrappedRoboModel):
     """
     Wrapper for PyBNN's BOHAMIANN model
 
@@ -216,6 +221,7 @@ class OrionBohamiannWrapper(BaseModel):
         likelihood_function=nll,
         print_every_n_steps: int = 100,
     ):
+        super().__init__()
         self.lower = lower
         self.upper = upper
         self.num_steps = num_steps

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -279,7 +279,7 @@ class OrionDNGOWrapper(DNGO, WrappedRoboModel):
 
             average_batch_loss = self.train_epoch(self.X, self.y)
 
-            loss_per_epoch[average_batch_loss] = average_batch_loss
+            loss_per_epoch[epoch] = average_batch_loss
 
             logger.debug(  # pylint: disable=logging-too-many-args
                 "Epoch {} of {}",

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -1,11 +1,23 @@
 """
 Wrapper for RoBO with DNGO
 """
+from __future__ import annotations
+
+from typing import Sequence
 import numpy
 import torch
 from pybnn.dngo import DNGO
+from typing_extensions import Literal
 
-from orion.algo.robo.base import RoBO, build_bounds, build_kernel, infer_n_hypers
+from orion.algo.robo.base import (
+    RoBO,
+    build_bounds,
+    build_kernel,
+    infer_n_hypers,
+    MaximizerName,
+    AcquisitionFnName,
+)
+from orion.algo.space import Space
 
 
 class RoBO_DNGO(RoBO):
@@ -62,36 +74,34 @@ class RoBO_DNGO(RoBO):
 
     def __init__(
         self,
-        space,
-        seed=0,
-        n_initial_points=20,
-        maximizer="random",
-        acquisition_func="log_ei",
-        normalize_input=True,
-        normalize_output=False,
-        chain_length=2000,
-        burnin_steps=2000,
-        batch_size=10,
-        num_epochs=500,
-        learning_rate=1e-2,
-        adapt_epoch=5000,
+        space: Space,
+        seed: int | Sequence[int] | None = 0,
+        n_initial_points: int = 20,
+        maximizer: MaximizerName = "random",
+        acquisition_func: AcquisitionFnName = "log_ei",
+        normalize_input: bool = True,
+        normalize_output: bool = False,
+        chain_length: int = 2000,
+        burnin_steps: int = 2000,
+        batch_size: int = 10,
+        num_epochs: int = 500,
+        learning_rate: float = 1e-2,
+        adapt_epoch: int = 5000,
     ):
 
-        super().__init__(
-            space,
-            seed=seed,
-            n_initial_points=n_initial_points,
-            maximizer=maximizer,
-            acquisition_func=acquisition_func,
-            normalize_input=normalize_input,
-            normalize_output=normalize_output,
-            chain_length=chain_length,
-            burnin_steps=burnin_steps,
-            batch_size=batch_size,
-            num_epochs=num_epochs,
-            learning_rate=learning_rate,
-            adapt_epoch=adapt_epoch,
-        )
+        super().__init__(space=space)
+        self.seed = seed
+        self.n_initial_points = n_initial_points
+        self.maximizer = maximizer
+        self.acquisition_func = acquisition_func
+        self.normalize_input = normalize_input
+        self.normalize_output = normalize_output
+        self.chain_length = chain_length
+        self.burnin_steps = burnin_steps
+        self.batch_size = batch_size
+        self.num_epochs = num_epochs
+        self.learning_rate = learning_rate
+        self.adapt_epoch = adapt_epoch
 
     def _initialize_model(self):
         lower, upper = build_bounds(self.space)

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -215,4 +215,3 @@ class RoBO_DNGO(RoBO[OrionDNGOWrapper]):
             lower=lower,
             upper=upper,
         )
-

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -3,13 +3,27 @@ Wrapper for RoBO with DNGO
 """
 from __future__ import annotations
 
-from typing import Sequence
+import logging
+from typing import OrderedDict, Sequence
 
 import numpy
+import numpy as np
 import torch
 from orion.algo.space import Space
-from pybnn.dngo import DNGO
-from typing_extensions import Literal
+from pybnn.dngo import (
+    DNGO,
+    BaseModel,
+    BayesianLinearRegression,
+    Net,
+    Prior,
+    emcee,
+    optim,
+    optimize,
+    time,
+    zero_mean_unit_var_denormalization,
+    zero_mean_unit_var_normalization,
+)
+from torch.nn import functional as F
 
 from orion.algo.robo.base import (
     AcquisitionFnName,
@@ -20,6 +34,8 @@ from orion.algo.robo.base import (
     build_kernel,
     infer_n_hypers,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OrionDNGOWrapper(DNGO, WrappedRoboModel):
@@ -66,27 +82,104 @@ class OrionDNGOWrapper(DNGO, WrappedRoboModel):
 
     """
 
-    def __init__(self, lower, upper, **kwargs):
-
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        lower: numpy.ndarray,
+        upper: numpy.ndarray,
+        device: torch.device | str | None = None,
+        batch_size: int = 10,
+        num_epochs: int = 500,
+        learning_rate: float = 0.01,
+        adapt_epoch: int = 5000,
+        n_units_1: int = 50,
+        n_units_2: int = 50,
+        n_units_3: int = 50,
+        alpha: float = 1.0,
+        beta: float = 1000,
+        prior: Prior | None = None,
+        do_mcmc: bool = True,
+        n_hypers: int = 20,
+        chain_length: int = 2000,
+        burnin_steps: int = 2000,
+        normalize_input: int = True,
+        normalize_output: int = True,
+        rng: numpy.random.RandomState | None = None,
+    ):
+        super().__init__(
+            batch_size=batch_size,
+            num_epochs=num_epochs,
+            learning_rate=learning_rate,
+            adapt_epoch=adapt_epoch,
+            n_units_1=n_units_1,
+            n_units_2=n_units_2,
+            n_units_3=n_units_3,
+            alpha=alpha,
+            beta=beta,
+            prior=prior,
+            do_mcmc=do_mcmc,
+            n_hypers=n_hypers,
+            chain_length=chain_length,
+            burnin_steps=burnin_steps,
+            normalize_input=normalize_input,
+            normalize_output=normalize_output,
+            rng=rng,
+        )
         self.lower = lower
         self.upper = upper
+        self.device = torch.device(
+            device or ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        self.prior: Prior
 
-    def set_state(self, state_dict):
+        # Cache to prevent retraining on the same data.
+        self._X: numpy.ndarray | None = None
+        self._y: numpy.ndarray | None = None
+        self._do_optimize: bool | None = None
+
+        self.network: Net
+        self.optimizer: optim.Adam
+        self._initial_network_weights: OrderedDict[str, torch.Tensor]
+        self._initial_optimizer_state: dict
+        self._create_modules()
+
+    def _create_modules(self):
+        """Create the network and the optimizer, using the global torch RNG."""
+        assert self.lower.ndim == 1
+        self.network = Net(
+            n_inputs=self.lower.shape[0],
+            n_units=[self.n_units_1, self.n_units_2, self.n_units_3],
+        ).to(self.device)
+
+        self.optimizer = optim.Adam(
+            self.network.parameters(), lr=self.init_learning_rate
+        )
+        # Copies of the network and optimizer parameters, so we just reload the weights rather than
+        # recreate a new network at each iteration.
+        self._initial_network_weights = self.network.state_dict()
+        self._initial_optimizer_state = self.optimizer.state_dict()
+
+    def set_state(self, state_dict: dict) -> None:
         """Restore the state of the optimizer"""
         torch.random.set_rng_state(state_dict["torch"])
+        if torch.cuda.is_available() and state_dict["torch_cuda"] is not None:
+            torch.cuda.set_rng_state_all(state_dict["torch_cuda"])
         self.rng.set_state(state_dict["rng"])
         self.prior.rng.set_state(state_dict["prior_rng"])
 
-    def state_dict(self):
-        """Return the current state of the optimizer so that it can be restored"""
+    def state_dict(self) -> dict:
+        """Return the current state algorithm so that it can be restored."""
+        # NOTE: In the case of DNGO, we just need to save the RNG state, since the networks are
+        # not reused between iterations.
         return {
             "torch": torch.random.get_rng_state(),
+            "torch_cuda": (
+                torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
+            ),
             "rng": self.rng.get_state(),
             "prior_rng": self.prior.rng.get_state(),
         }
 
-    def seed(self, seed):
+    def seed(self, seed: int) -> None:
         """Seed all internal RNGs"""
         self.rng = numpy.random.RandomState(seed)
         rand_nums = self.rng.randint(1, int(10e8), 2)
@@ -100,6 +193,232 @@ class OrionDNGOWrapper(DNGO, WrappedRoboModel):
         torch.manual_seed(pytorch_seed)
 
         self.prior.rng.seed(rand_nums[1])
+        # Recreate the modules using that RNG seed.
+        self._create_modules()
+
+    def _to_tensor(self, v: numpy.ndarray) -> torch.Tensor:
+        return torch.as_tensor(v, device=self.device, dtype=torch.float32)
+
+    @staticmethod
+    def _to_numpy(v: torch.Tensor) -> numpy.ndarray:
+        return v.detach().cpu().numpy()
+
+    @BaseModel._check_shapes_train  # type: ignore
+    def train(self, X: numpy.ndarray, y: numpy.ndarray, do_optimize: bool = True):
+        """
+        Trains the model on the provided data.
+
+        NOTE: Overwritten here to fix the following issues:
+        - memory leak in the training loop due to accumulating (and storing) live losses.
+        - Add cuda training when available
+        - reload initial weights instead of re-creating the model and optimizer at each iteration.
+
+        Parameters
+        ----------
+        X: np.ndarray (N, D)
+            Input data points. The dimensionality of X is (N, D),
+            with N as the number of points and D is the number of features.
+        y: np.ndarray (N,)
+            The corresponding target values.
+        do_optimize: boolean
+            If set to true the hyperparameters are optimized otherwise
+            the default hyperparameters are used.
+
+        """
+        start_time = time.time()
+        logger.info(f"Starting training with {X.shape[0]} samples")
+
+        if self._X is None or self._y is None:
+            logger.info("Training for the first time.")
+        elif (
+            self._X.shape == X.shape
+            and numpy.allclose(self._X, X)
+            and self._y.shape == y.shape
+            and numpy.allclose(self._y, y)
+            and self._do_optimize == do_optimize
+        ):
+            logger.info("Skipping training, since we've already trained on this data")
+            return
+        else:
+            logger.info("Training with additional points")
+            assert self.network is not None
+            assert self.optimizer is not None
+            assert self._initial_network_weights is not None
+            assert self._initial_optimizer_state is not None
+            self.network.load_state_dict(self._initial_network_weights)
+            self.optimizer.load_state_dict(self._initial_optimizer_state)
+
+        self._X = X
+        self._y = y
+        self._do_optimize = do_optimize
+
+        # Normalize inputs
+        if self.normalize_input:
+            self.X, self.X_mean, self.X_std = zero_mean_unit_var_normalization(X)
+        else:
+            self.X = X
+
+        # Normalize outputs
+        if self.normalize_output:
+            self.y, self.y_mean, self.y_std = zero_mean_unit_var_normalization(y)
+        else:
+            self.y = y
+
+        self.y = self.y[:, None]
+
+        # Check if we have enough points to create a minibatch otherwise use all data points
+        if self.X.shape[0] <= self.batch_size:
+            batch_size = self.X.shape[0]
+        else:
+            batch_size = self.batch_size
+
+        # Create the neural network
+        features = X.shape[1]
+        # TODO: Reinitialize the network weights, rather than re-create them?
+
+        # Start training
+        lc = np.zeros([self.num_epochs])
+
+        for epoch in range(self.num_epochs):
+
+            epoch_start_time = time.time()
+
+            train_err: torch.Tensor | float = 0.0
+            train_batches = 0
+
+            for train_batches, batch in enumerate(
+                self.iterate_minibatches(self.X, self.y, batch_size, shuffle=True)
+            ):
+                inputs = self._to_tensor(batch[0])
+                targets = self._to_tensor(batch[1])
+
+                self.optimizer.zero_grad()
+                output = self.network(inputs)
+                loss = F.mse_loss(output, targets)
+                loss.backward()
+                self.optimizer.step()
+
+                train_err += loss.detach()
+
+            lc[epoch] = train_err / train_batches
+            logger.debug("Epoch {} of {}", epoch + 1, self.num_epochs)
+            curtime = time.time()
+            epoch_time = curtime - epoch_start_time
+            total_time = curtime - start_time
+            logger.debug(
+                "Epoch time {:.3f}s, total time {:.3f}s", epoch_time, total_time
+            )
+
+            logger.debug("Training loss:\t\t{:.5g}", train_err / train_batches)
+
+        # Design matrix
+        self.Theta = self._to_numpy(self.network.basis_funcs(self._to_tensor(self.X)))
+
+        if do_optimize:
+            if self.do_mcmc:
+                self.sampler = emcee.EnsembleSampler(
+                    self.n_hypers, 2, self.marginal_log_likelihood
+                )
+
+                # Do a burn-in in the first iteration
+                if not self.burned:
+                    # Initialize the walkers by sampling from the prior
+                    self.p0 = self.prior.sample_from_prior(self.n_hypers)
+                    # Run MCMC sampling
+                    # NOTE: This has changed with the newer emcee versions:
+                    self.p0, _, _ = self.sampler.run_mcmc(
+                        self.p0, self.burnin_steps, rstate0=self.rng
+                    )
+
+                    self.burned = True
+
+                # Start sampling
+                pos, _, _ = self.sampler.run_mcmc(
+                    self.p0, self.chain_length, rstate0=self.rng
+                )
+
+                # Save the current position, it will be the startpoint in
+                # the next iteration
+                self.p0 = pos
+
+                # Take the last samples from each walker set them back on a linear scale
+                linear_theta = np.exp(self.sampler.chain[:, -1])
+                self.hypers = linear_theta
+                self.hypers[:, 1] = 1 / self.hypers[:, 1]
+            else:
+                # Optimize hyperparameters of the Bayesian linear regression
+                p0 = self.prior.sample_from_prior(n_samples=1)
+                res = optimize.fmin(self.negative_mll, p0)
+                self.hypers = [[np.exp(res[0]), 1 / np.exp(res[1])]]
+        else:
+
+            self.hypers = [[self.alpha, self.beta]]
+
+        logger.info("Hypers: %s" % self.hypers)
+        self.models: list = []
+        for sample in self.hypers:
+            # Instantiate a model for each hyperparameter configuration
+            model = BayesianLinearRegression(
+                alpha=sample[0], beta=sample[1], basis_func=None
+            )
+            model.train(self.Theta, self.y[:, 0], do_optimize=False)
+
+            self.models.append(model)
+
+    @BaseModel._check_shapes_predict
+    def predict(self, X_test: numpy.ndarray) -> tuple[numpy.ndarray, numpy.ndarray]:
+        r"""
+        Returns the predictive mean and variance of the objective function at
+        the given test points.
+
+        Parameters
+        ----------
+        X_test: np.ndarray (N, D)
+            N input test points
+
+        Returns
+        ----------
+        np.array(N,)
+            predictive mean
+        np.array(N,)
+            predictive variance
+
+        """
+        # Normalize inputs
+        if self.normalize_input:
+            X_, _, _ = zero_mean_unit_var_normalization(X_test, self.X_mean, self.X_std)
+        else:
+            X_ = X_test
+
+        # Get features from the net
+
+        theta = self._to_numpy(self.network.basis_funcs(self._to_tensor(X_)))
+
+        # Marginalise predictions over hyperparameters of the BLR
+        mu = np.zeros([len(self.models), X_test.shape[0]])
+        var = np.zeros([len(self.models), X_test.shape[0]])
+
+        for i, m in enumerate(self.models):
+            mu[i], var[i] = m.predict(theta)
+
+        # See the algorithm runtime prediction paper by Hutter et al
+        # for the derivation of the total variance
+        m = np.mean(mu, axis=0)
+        v = np.mean(mu**2 + var, axis=0) - m**2
+
+        # Clip negative variances and set them to the smallest
+        # positive float value
+        if v.shape[0] == 1:
+            v = np.clip(v, np.finfo(v.dtype).eps, np.inf)
+        else:
+            v = np.clip(v, np.finfo(v.dtype).eps, np.inf)
+            v[np.where((v < np.finfo(v.dtype).eps) & (v > -np.finfo(v.dtype).eps))] = 0
+
+        if self.normalize_output:
+            m = zero_mean_unit_var_denormalization(m, self.y_mean, self.y_std)
+            v *= self.y_std**2
+
+        return m, v
 
 
 class RoBO_DNGO(RoBO[OrionDNGOWrapper]):

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -4,21 +4,22 @@ Wrapper for RoBO with DNGO
 from __future__ import annotations
 
 from typing import Sequence
+
 import numpy
 import torch
+from orion.algo.space import Space
 from pybnn.dngo import DNGO
 from typing_extensions import Literal
 
 from orion.algo.robo.base import (
+    AcquisitionFnName,
+    MaximizerName,
     RoBO,
+    WrappedRoboModel,
     build_bounds,
     build_kernel,
     infer_n_hypers,
-    MaximizerName,
-    AcquisitionFnName,
-    WrappedRoboModel,
 )
-from orion.algo.space import Space
 
 
 class OrionDNGOWrapper(DNGO, WrappedRoboModel):

--- a/src/orion/algo/robo/dngo.py
+++ b/src/orion/algo/robo/dngo.py
@@ -77,7 +77,7 @@ class RoBO_DNGO(RoBO):
         adapt_epoch=5000,
     ):
 
-        super(RoBO_DNGO, self).__init__(
+        super().__init__(
             space,
             seed=seed,
             n_initial_points=n_initial_points,
@@ -165,7 +165,7 @@ class OrionDNGOWrapper(DNGO):
 
     def __init__(self, lower, upper, **kwargs):
 
-        super(OrionDNGOWrapper, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.lower = lower
         self.upper = upper
 

--- a/src/orion/algo/robo/gp.py
+++ b/src/orion/algo/robo/gp.py
@@ -59,7 +59,7 @@ class RoBO_GP(RoBO):
         normalize_output=False,
     ):
 
-        super(RoBO_GP, self).__init__(
+        super().__init__(
             space,
             maximizer=maximizer,
             acquisition_func=acquisition_func,
@@ -138,7 +138,7 @@ class RoBO_GP_MCMC(RoBO):
         burnin_steps=2000,
     ):
 
-        super(RoBO_GP_MCMC, self).__init__(
+        super().__init__(
             space,
             seed=seed,
             n_initial_points=n_initial_points,
@@ -152,7 +152,7 @@ class RoBO_GP_MCMC(RoBO):
 
     def build_acquisition_func(self):
         """Build a marginalized acquisition function with MCMC."""
-        return MarginalizationGPMCMC(super(RoBO_GP_MCMC, self).build_acquisition_func())
+        return MarginalizationGPMCMC(super().build_acquisition_func())
 
     def _initialize_model(self):
         lower, upper = build_bounds(self.space)

--- a/src/orion/algo/robo/gp.py
+++ b/src/orion/algo/robo/gp.py
@@ -2,21 +2,24 @@
 Wrapper for RoBO with GP (and MCMC)
 """
 from __future__ import annotations
+
 from typing import Sequence
+
 import numpy
+from orion.algo.space import Space
 from robo.acquisition_functions.marginalization import MarginalizationGPMCMC
 from robo.models.gaussian_process import GaussianProcess
 from robo.models.gaussian_process_mcmc import GaussianProcessMCMC
-from orion.algo.space import Space
+
 from orion.algo.robo.base import (
+    AcquisitionFnName,
+    MaximizerName,
     RoBO,
+    WrappedRoboModel,
     build_bounds,
     build_kernel,
     build_prior,
     infer_n_hypers,
-    AcquisitionFnName,
-    MaximizerName,
-    WrappedRoboModel,
 )
 
 

--- a/src/orion/algo/robo/gp.py
+++ b/src/orion/algo/robo/gp.py
@@ -1,18 +1,22 @@
 """
 Wrapper for RoBO with GP (and MCMC)
 """
-
+from __future__ import annotations
+from typing import Sequence
 import numpy
 from robo.acquisition_functions.marginalization import MarginalizationGPMCMC
 from robo.models.gaussian_process import GaussianProcess
 from robo.models.gaussian_process_mcmc import GaussianProcessMCMC
-
+from orion.algo.space import Space
 from orion.algo.robo.base import (
     RoBO,
     build_bounds,
     build_kernel,
     build_prior,
     infer_n_hypers,
+    AcquisitionFnName,
+    MaximizerName,
+    WrappedRoboModel,
 )
 
 
@@ -50,30 +54,29 @@ class RoBO_GP(RoBO):
 
     def __init__(
         self,
-        space,
-        seed=0,
-        n_initial_points=20,
-        maximizer="random",
-        acquisition_func="log_ei",
-        normalize_input=True,
-        normalize_output=False,
+        space: Space,
+        seed: int | Sequence[int] | None = 0,
+        n_initial_points: int = 20,
+        maximizer: MaximizerName = "random",
+        acquisition_func: AcquisitionFnName = "log_ei",
+        normalize_input: bool = True,
+        normalize_output: bool = False,
     ):
-
         super().__init__(
-            space,
+            space=space,
+            seed=seed,
+            n_initial_points=n_initial_points,
             maximizer=maximizer,
             acquisition_func=acquisition_func,
-            normalize_input=normalize_input,
-            normalize_output=normalize_output,
-            n_initial_points=n_initial_points,
-            seed=seed,
         )
+        self.normalize_input = normalize_input
+        self.normalize_output = normalize_output
 
-    def _initialize_model(self):
+    def build_model(self) -> OrionGaussianProcessWrapper:
         lower, upper = build_bounds(self.space)
         kernel = build_kernel(lower, upper)
         prior = build_prior(kernel)
-        self.model = OrionGaussianProcessWrapper(
+        return OrionGaussianProcessWrapper(
             kernel,
             prior=prior,
             rng=None,
@@ -84,7 +87,7 @@ class RoBO_GP(RoBO):
         )
 
 
-class RoBO_GP_MCMC(RoBO):
+class RoBO_GP_MCMC(RoBO_GP):
     """
     Wrapper for RoBO with Gaussian processes using Markov chain Monte Carlo
     to marginalize out hyperparameters of the Bayesian Optimization.
@@ -127,17 +130,16 @@ class RoBO_GP_MCMC(RoBO):
 
     def __init__(
         self,
-        space,
-        seed=0,
-        n_initial_points=20,
-        maximizer="random",
-        acquisition_func="log_ei",
-        normalize_input=True,
-        normalize_output=False,
+        space: Space,
+        seed: int | Sequence[int] | None = 0,
+        n_initial_points: int = 20,
+        maximizer: MaximizerName = "random",
+        acquisition_func: AcquisitionFnName = "log_ei",
+        normalize_input: bool = True,
+        normalize_output: bool = False,
         chain_length=2000,
         burnin_steps=2000,
     ):
-
         super().__init__(
             space,
             seed=seed,
@@ -146,20 +148,20 @@ class RoBO_GP_MCMC(RoBO):
             acquisition_func=acquisition_func,
             normalize_input=normalize_input,
             normalize_output=normalize_output,
-            chain_length=chain_length,
-            burnin_steps=burnin_steps,
         )
+        self.chain_length = chain_length
+        self.burnin_steps = burnin_steps
 
-    def build_acquisition_func(self):
+    def build_acquisition_func(self) -> MarginalizationGPMCMC:
         """Build a marginalized acquisition function with MCMC."""
         return MarginalizationGPMCMC(super().build_acquisition_func())
 
-    def _initialize_model(self):
+    def build_model(self) -> OrionGaussianProcessMCMCWrapper:
         lower, upper = build_bounds(self.space)
         kernel = build_kernel(lower, upper)
         prior = build_prior(kernel)
         n_hypers = infer_n_hypers(kernel)
-        self.model = OrionGaussianProcessMCMCWrapper(
+        return OrionGaussianProcessMCMCWrapper(
             kernel,
             prior=prior,
             n_hypers=n_hypers,
@@ -173,7 +175,7 @@ class RoBO_GP_MCMC(RoBO):
         )
 
 
-class OrionGaussianProcessWrapper(GaussianProcess):
+class OrionGaussianProcessWrapper(GaussianProcess, WrappedRoboModel):
     """
     Wrapper for RoBO's Gaussian processes model
 
@@ -203,14 +205,14 @@ class OrionGaussianProcessWrapper(GaussianProcess):
 
     """
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: dict) -> None:
         """Restore the state of the optimizer"""
         self.rng.set_state(state_dict["model_rng_state"])
         self.prior.rng.set_state(state_dict["prior_rng_state"])
         self.kernel.set_parameter_vector(state_dict["model_kernel_parameter_vector"])
         self.noise = state_dict["noise"]
 
-    def state_dict(self):
+    def state_dict(self) -> dict:
         """Return the current state of the optimizer so that it can be restored"""
         return {
             "prior_rng_state": self.prior.rng.get_state(),
@@ -219,14 +221,14 @@ class OrionGaussianProcessWrapper(GaussianProcess):
             "noise": self.noise,
         }
 
-    def seed(self, seed):
+    def seed(self, seed: int | Sequence[int] | None) -> None:
         """Seed all internal RNGs"""
-        seeds = numpy.random.RandomState(seed).randint(1, 10e8, size=2)
+        seeds = numpy.random.RandomState(seed).randint(1, int(10e8), size=2)
         self.rng.seed(seeds[0])
         self.prior.rng.seed(seeds[1])
 
 
-class OrionGaussianProcessMCMCWrapper(GaussianProcessMCMC):
+class OrionGaussianProcessMCMCWrapper(GaussianProcessMCMC, WrappedRoboModel):
     """
     Wrapper for RoBO's Gaussian processes with MCMC model
 
@@ -257,7 +259,7 @@ class OrionGaussianProcessMCMCWrapper(GaussianProcessMCMC):
 
     """
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: dict) -> None:
         """Restore the state of the optimizer"""
         self.rng.set_state(state_dict["model_rng_state"])
         self.prior.rng.set_state(state_dict["prior_rng_state"])
@@ -269,7 +271,7 @@ class OrionGaussianProcessMCMCWrapper(GaussianProcessMCMC):
             delattr(self, "p0")
             self.burned = False
 
-    def state_dict(self):
+    def state_dict(self) -> dict:
         """Return the current state of the optimizer so that it can be restored"""
         s_dict = {
             "prior_rng_state": self.prior.rng.get_state(),
@@ -281,8 +283,8 @@ class OrionGaussianProcessMCMCWrapper(GaussianProcessMCMC):
 
         return s_dict
 
-    def seed(self, seed):
+    def seed(self, seed: int | Sequence[int] | None) -> None:
         """Seed all internal RNGs"""
-        seeds = numpy.random.RandomState(seed).randint(1, 10e8, size=2)
+        seeds = numpy.random.RandomState(seed).randint(1, int(10e8), size=2)
         self.rng.seed(seeds[0])
         self.prior.rng.seed(seeds[1])

--- a/src/orion/algo/robo/gp.py
+++ b/src/orion/algo/robo/gp.py
@@ -76,6 +76,7 @@ class RoBO_GP(RoBO):
         self.normalize_output = normalize_output
 
     def build_model(self) -> OrionGaussianProcessWrapper:
+        """Builds the model for the optimisation."""
         lower, upper = build_bounds(self.space)
         kernel = build_kernel(lower, upper)
         prior = build_prior(kernel)
@@ -123,7 +124,7 @@ class RoBO_GP_MCMC(RoBO_GP):
     chain_length: int
         The length of the MCMC chain. We start ``n_hypers`` walker for chain_length
         steps and we use the last sample in the chain as a hyperparameter sample.
-        ``n_hypers`` is automatically infered based on dimensionality of the search space.
+        ``n_hypers`` is automatically inferred based on dimensionality of the search space.
         Defaults to 2000.
     burnin_steps: int
         The number of burnin steps before the actual MCMC sampling starts.

--- a/src/orion/algo/robo/randomforest.py
+++ b/src/orion/algo/robo/randomforest.py
@@ -59,7 +59,7 @@ class RoBO_RandomForest(RoBO):
         return_total_variance=True,
     ):
 
-        super(RoBO_RandomForest, self).__init__(
+        super().__init__(
             space,
             maximizer=maximizer,
             acquisition_func=acquisition_func,
@@ -123,7 +123,7 @@ class OrionRandomForestWrapper(RandomForest):
         rng=None,
     ):
 
-        super(OrionRandomForestWrapper, self).__init__(
+        super().__init__(
             num_trees=num_trees,
             do_bootstrapping=do_bootstrapping,
             n_points_per_tree=n_points_per_tree,
@@ -142,7 +142,7 @@ class OrionRandomForestWrapper(RandomForest):
         # NOTE: We cannot save `reg_rng` state so instead we control it
         #       with random integers sampled from `rng` and keep track of `rng` state.
         self.reg_rng = reg.default_random_engine(int(self.rng.randint(10e8)))
-        super(OrionRandomForestWrapper, self).train(X, y, **kwargs)
+        super().train(X, y, **kwargs)
 
     def predict(self, X_test, **kwargs):
         """
@@ -151,7 +151,7 @@ class OrionRandomForestWrapper(RandomForest):
         # NOTE: We cannot save `reg_rng` state so instead we control it
         #       with random integers sampled from `rng` and keep track of `rng` state.
         self.reg_rng = reg.default_random_engine(int(self.rng.randint(10e8)))
-        return super(OrionRandomForestWrapper, self).predict(X_test, **kwargs)
+        return super().predict(X_test, **kwargs)
 
     def set_state(self, state_dict):
         """Restore the state of the optimizer"""

--- a/src/orion/algo/robo/randomforest.py
+++ b/src/orion/algo/robo/randomforest.py
@@ -1,10 +1,16 @@
 """
 Wrapper for RoBO with Random Forest
 """
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy
 import pyrfr.regression as reg
+from orion.algo.space import Space
 from robo.models.random_forest import RandomForest
 
-from orion.algo.robo.base import RoBO, build_bounds
+from orion.algo.robo.base import AcquisitionFnName, MaximizerName, RoBO, build_bounds
 
 
 class RoBO_RandomForest(RoBO):
@@ -47,34 +53,34 @@ class RoBO_RandomForest(RoBO):
 
     def __init__(
         self,
-        space,
-        seed=0,
+        space: Space,
+        seed: int | Sequence[int] | None = 0,
         n_initial_points=20,
-        maximizer="random",
-        acquisition_func="log_ei",
-        num_trees=30,
-        do_bootstrapping=True,
-        n_points_per_tree=0,
-        compute_oob_error=False,
-        return_total_variance=True,
+        maximizer: MaximizerName = "random",
+        acquisition_func: AcquisitionFnName = "log_ei",
+        num_trees: int = 30,
+        do_bootstrapping: bool = True,
+        n_points_per_tree: int = 0,
+        compute_oob_error: bool = False,
+        return_total_variance: bool = True,
     ):
 
         super().__init__(
             space,
             maximizer=maximizer,
             acquisition_func=acquisition_func,
-            num_trees=num_trees,
-            do_bootstrapping=do_bootstrapping,
-            n_points_per_tree=n_points_per_tree,
-            compute_oob_error=compute_oob_error,
-            return_total_variance=return_total_variance,
             n_initial_points=n_initial_points,
             seed=seed,
         )
+        self.num_trees = num_trees
+        self.do_bootstrapping = do_bootstrapping
+        self.n_points_per_tree = n_points_per_tree
+        self.compute_oob_error = compute_oob_error
+        self.return_total_variance = return_total_variance
 
-    def _initialize_model(self):
+    def build_model(self):
         lower, upper = build_bounds(self.space)
-        self.model = OrionRandomForestWrapper(
+        return OrionRandomForestWrapper(
             rng=None,
             num_trees=self.num_trees,
             do_bootstrapping=self.do_bootstrapping,
@@ -135,25 +141,23 @@ class OrionRandomForestWrapper(RandomForest):
         self.lower = lower
         self.upper = upper
 
-    def train(self, X, y, **kwargs):
+    def train(self, X: numpy.ndarray, y: numpy.ndarray, **kwargs):
         """
         Seeds the RNG of Random Forest before calling parent's train().
         """
         # NOTE: We cannot save `reg_rng` state so instead we control it
         #       with random integers sampled from `rng` and keep track of `rng` state.
-        self.reg_rng = reg.default_random_engine(int(self.rng.randint(10e8)))
+        self.reg_rng = reg.default_random_engine(int(self.rng.randint(int(10e8))))
         super().train(X, y, **kwargs)
 
-    def predict(self, X_test, **kwargs):
-        """
-        Seeds the RNG of Random Forest before calling parent's predict().
-        """
+    def predict(self, X_test: numpy.ndarray, **kwargs):
+        # Seeds the RNG of Random Forest before calling parent's predict().
         # NOTE: We cannot save `reg_rng` state so instead we control it
         #       with random integers sampled from `rng` and keep track of `rng` state.
-        self.reg_rng = reg.default_random_engine(int(self.rng.randint(10e8)))
+        self.reg_rng = reg.default_random_engine(int(self.rng.randint(int(10e8))))
         return super().predict(X_test, **kwargs)
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: dict) -> None:
         """Restore the state of the optimizer"""
         self.rng.set_state(state_dict["model_rng_state"])
 

--- a/tests/benchmark/rosenbrock.py
+++ b/tests/benchmark/rosenbrock.py
@@ -12,7 +12,7 @@ def rosenbrock_function(x, y):
     """Evaluate a n-D rosenbrock function."""
     x = numpy.asarray(x)
     summands = 100 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2
-    return numpy.sum(summands) + y ** 2
+    return numpy.sum(summands) + y**2
 
 
 def execute():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,7 +233,7 @@ class TestRoBO_BOHAMIANN(BaseRoBOTests):
             sampling_method="sgld",
             use_double_precision=False,
             n_initial_points=N_INIT + 1,
-            **train_config
+            **train_config,
         )
 
         # Adapt to bnn.train interface
@@ -258,4 +258,3 @@ class TestRoBO_BOHAMIANN(BaseRoBOTests):
         algo.suggest(1)
         assert spy.call_count > 0
         assert spy.call_args[1] == train_config
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,13 +2,11 @@
 # -*- coding: utf-8 -*-
 """Perform integration tests for `orion.algo.robo`."""
 import copy
-import functools
 import itertools
-import os
+from typing import ClassVar, Type
 
-import numpy
-import orion.core.cli
-import pytest
+from orion.core.utils.format_trials import tuple_to_trial
+from orion.core.worker.trial import Trial
 from orion.testing.algo import BaseAlgoTests
 
 N_INIT = 10
@@ -24,38 +22,38 @@ class BaseRoBOTests(BaseAlgoTests):
     def test_suggest_init(self, mocker):
         algo = self.create_algo()
         spy = self.spy_phase(mocker, 0, algo, "space.sample")
-        points = algo.suggest(1000)
-        assert len(points) == N_INIT
+        trials = algo.suggest(1000)
+        assert len(trials) == N_INIT
 
     def test_suggest_init_missing(self, mocker):
         algo = self.create_algo()
         missing = 3
         spy = self.spy_phase(mocker, N_INIT - missing, algo, "space.sample")
-        points = algo.suggest(1000)
-        assert len(points) == missing
+        trials = algo.suggest(1000)
+        assert len(trials) == missing
 
     def test_suggest_init_overflow(self, mocker):
         algo = self.create_algo()
         spy = self.spy_phase(mocker, N_INIT - 1, algo, "space.sample")
         # Now reaching N_INIT
-        points = algo.suggest(1000)
-        assert len(points) == 1
+        trials = algo.suggest(1000)
+        assert len(trials) == 1
         # Verify point was sampled randomly, not using BO
         assert spy.call_count == 1
         # Overflow above N_INIT
-        points = algo.suggest(1000)
-        assert len(points) == 1
+        trials = algo.suggest(1000)
+        assert len(trials) == 1
         # Verify point was sampled randomly, not using BO
         assert spy.call_count == 2
 
     def test_suggest_n(self, mocker, num, attr):
         algo = self.create_algo()
         spy = self.spy_phase(mocker, num, algo, attr)
-        points = algo.suggest(5)
+        trials = algo.suggest(5)
         if num == 0:
-            assert len(points) == 5
+            assert len(trials) == 5
         else:
-            assert len(points) == 1
+            assert len(trials) == 1
 
     def test_is_done_cardinality(self):
         # TODO: Support correctly loguniform(discrete=True)
@@ -71,10 +69,13 @@ class BaseRoBOTests(BaseAlgoTests):
         assert space.cardinality == 5 * 3 * 6
 
         algo = self.create_algo(space=space)
+        i = 0
         for i, (x, y, z) in enumerate(itertools.product(range(5), "abc", range(1, 7))):
             assert not algo.is_done
             n = len(algo.algorithm._trials_info)
-            algo.observe([[x, y, z]], [dict(objective=i)])
+            trial = tuple_to_trial((x, y, z), space=algo.space)
+            trial.results = [Trial.Result(type="objective", value=i)]
+            algo.observe([trial])
             assert len(algo.algorithm._trials_info) == n + 1
 
         assert i + 1 == space.cardinality

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,6 +37,7 @@ class BaseRoBOTests(BaseAlgoTests[RoboAlgoType]):
         super().__init_subclass__()
         cls.algo_name = cls.algo_type.__name__.lower()
 
+    @first_phase_only
     def test_suggest_init(self, phase: TestPhase):
         algo = self.create_algo()
         trials = algo.suggest(num=phase.length)
@@ -173,6 +174,7 @@ class TestRoBO_DNGO(BaseRoBOTests[RoBO_DNGO]):
         "batch_size": 10,
         "num_epochs": 10,
         "adapt_epoch": 20,
+        "num_epochs": 10,
         "n_initial_points": N_INIT // 2,
         "seed": 1234,
     }
@@ -240,7 +242,7 @@ class TestRoBO_BOHAMIANN(BaseRoBOTests[RoBO_BOHAMIANN]):
     ]
 
     def test_configuration_to_model(self, mocker):
-
+        """Test that the values passed in the configuration make their way to the model."""
         train_config = dict(
             burnin_steps=self.config["burnin_steps"] * 2,
             num_steps=500,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ def modified_config(config, **kwargs):
 RoboAlgoType = TypeVar("RoboAlgoType", bound=RoBO)
 
 
-class BaseRoBOTests(BaseAlgoTests[RoboAlgoType]):
+class BaseRoBOTests(BaseAlgoTests):
     # To be overwritten by subclasses:
     algo_type: ClassVar[type[RoBO]] = RoBO
 
@@ -105,7 +105,7 @@ class BaseRoBOTests(BaseAlgoTests[RoboAlgoType]):
         assert algo.is_done
 
 
-class TestRoBO_GP(BaseRoBOTests[RoBO_GP]):
+class TestRoBO_GP(BaseRoBOTests):
     algo_type: ClassVar[type[RoBO]] = RoBO_GP
     config = {
         "maximizer": "random",
@@ -122,7 +122,7 @@ class TestRoBO_GP(BaseRoBOTests[RoBO_GP]):
     ]
 
 
-class TestRoBO_GP_MCMC(BaseRoBOTests[RoBO_GP_MCMC]):
+class TestRoBO_GP_MCMC(BaseRoBOTests):
     algo_type: ClassVar[type[RoBO]] = RoBO_GP_MCMC
     config = {
         "maximizer": "random",
@@ -141,7 +141,7 @@ class TestRoBO_GP_MCMC(BaseRoBOTests[RoBO_GP_MCMC]):
 
 
 @pytest.mark.skip(reason="pyrfr seems to have changed.")
-class TestRoBO_RandomForest(BaseRoBOTests[RoBO_RandomForest]):
+class TestRoBO_RandomForest(BaseRoBOTests):
     algo_type: ClassVar[type[RoBO]] = RoBO_RandomForest
     config = {
         "maximizer": "random",
@@ -160,7 +160,7 @@ class TestRoBO_RandomForest(BaseRoBOTests[RoBO_RandomForest]):
     ]
 
 
-class TestRoBO_DNGO(BaseRoBOTests[RoBO_DNGO]):
+class TestRoBO_DNGO(BaseRoBOTests):
     algo_type: ClassVar[type[RoBO]] = RoBO_DNGO
 
     config = {
@@ -216,7 +216,7 @@ class TestRoBO_DNGO(BaseRoBOTests[RoBO_DNGO]):
         assert model.batch_size == tmp_config["batch_size"]
 
 
-class TestRoBO_BOHAMIANN(BaseRoBOTests[RoBO_BOHAMIANN]):
+class TestRoBO_BOHAMIANN(BaseRoBOTests):
     algo_type: ClassVar[type[RoBO]] = RoBO_BOHAMIANN
     config = {
         "maximizer": "random",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Perform integration tests for `orion.algo.robo`."""
 from __future__ import annotations
 
-from abc import ABC
 import copy
 import itertools
-from typing import ClassVar, Type, TypeVar
+from typing import ClassVar, TypeVar
 
+import pytest
 from orion.core.utils.format_trials import tuple_to_trial
 from orion.core.worker.trial import Trial
 from orion.testing.algo import BaseAlgoTests, TestPhase, first_phase_only
-from orion.algo.robo.base import RoBO
-from orion.algo.robo.gp import RoBO_GP, RoBO_GP_MCMC
-from orion.algo.robo.bohamiann import RoBO_BOHAMIANN
-from orion.algo.robo.randomforest import RoBO_RandomForest
-from orion.algo.robo.dngo import RoBO_DNGO
 
+from orion.algo.robo.base import RoBO
+from orion.algo.robo.bohamiann import RoBO_BOHAMIANN
+from orion.algo.robo.dngo import RoBO_DNGO
+from orion.algo.robo.gp import RoBO_GP, RoBO_GP_MCMC
+from orion.algo.robo.randomforest import RoBO_RandomForest
 
 N_INIT = 10
 
@@ -140,6 +139,7 @@ class TestRoBO_GP_MCMC(BaseRoBOTests[RoBO_GP_MCMC]):
     ]
 
 
+@pytest.mark.skip(reason="pyrfr seems to have changed.")
 class TestRoBO_RandomForest(BaseRoBOTests[RoBO_RandomForest]):
     algo_type: ClassVar[type[RoBO]] = RoBO_RandomForest
     config = {

--- a/tox.ini
+++ b/tox.ini
@@ -53,13 +53,13 @@ basepython = python3
 skip_install = false
 deps =
     {[testenv:black]deps}
-    {[testenv:isort]deps}
     {[testenv:pylint]deps}
+    {[testenv:doc8]deps}
     {[testenv:packaging]deps}
 commands =
     {[testenv:black]commands}
-    {[testenv:isort]commands}
     {[testenv:pylint]commands}
+    {[testenv:doc8]commands}
     {[testenv:packaging]commands}
 
 [testenv:black]
@@ -85,7 +85,7 @@ description = Use isort to check import orders
 basepython = python3
 skip_install = true
 deps =
-    isort == 5.6.*
+    isort == 5.10.1
 commands =
     isort --profile black -c src/orion/ tests/
 

--- a/tox.ini
+++ b/tox.ini
@@ -163,7 +163,7 @@ deps =
     wheel
     setuptools
 commands =
-    python setup.py -q sdist bdist_wheel
+    python setup.py -q sdist
 
 [testenv:release]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ description = Verify code style with black
 basepython = python3
 skip_install = true
 deps =
-    black == 20.8b1
+    black == 22.3.0
 commands =
     black --check src/orion/ tests/
 


### PR DESCRIPTION
- Updates all algos to use the most recent version of Orion.
- Changes to the installation instructions (only one pip install step is required). 
- Temporarily disables the RandomForest model (dependency change needs to be fixed)
- Make tests a lot faster to run (DNGO in particular)
- Fix memory leak and innefficiencies in DNGO training loop.
- Add CUDA compatibility to DNGO

NOTE: This PR depends on https://github.com/Epistimio/orion/pull/886 being merged. Once it is, I'll mark this as ready for review.

